### PR TITLE
Children undefined fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,8 +18,8 @@ module.exports = function (file, opts) {
     })
     return { _expr: h + '(' + JSON.stringify(tagName)
       + ',{' + sopts.join(',') + '}'
-      + ',[' + children.map(child).join(',')
-      + '])' }
+      + (children && children.length ? (',[' + children.map(child).join(',') + ']') : '')
+      + ')' }
   }, { concat: concat })
   return through(write, end)
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "license": "BSD",
   "dependencies": {
     "falafel": "^1.2.0",
-    "hyperx": "^1.2.0",
+    "hyperx": "1.3.1",
     "through2": "^2.0.0"
   },
   "devDependencies": {

--- a/test/vdom/expected.html
+++ b/test/vdom/expected.html
@@ -1,5 +1,6 @@
 <div>
   <h1 y="ab3cd">hello world!</h1>
+  <input type="text" />
   <i>cool</i>
   wow
   <b>1</b><b>2</b><b>3</b>

--- a/test/vdom/source.js
+++ b/test/vdom/source.js
@@ -6,6 +6,7 @@ var title = 'world'
 var wow = [1,2,3]
 var tree = hx`<div>
   <h1 y="ab${1+2}cd">hello ${title}!</h1>
+  <input type="text">
   ${hx`<i>cool</i>`}
   wow
   ${wow.map(function (w, i) {


### PR DESCRIPTION
When using the latest version of `hyperx` `hyperxify` it fails when children is undefined.

This is [this commit].

This pull request fixes using `hyperxify` with the latest `hyperx`.

I updated the vdom test with an input element showing the failure.

[this commit]:https://github.com/JamesKyburz/hyperx/commit/36036ab6d16be70e73536a8bf53c69da940df7f3